### PR TITLE
共通エラーハンドラ導入 + AI レスポンスの JSON パース安全化

### DIFF
--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { generateSectionEdit } from '@/lib/ai';
 import { aiChatSchema, formatZodError } from '@/lib/validations';
+import { handleApiError } from '@/lib/errors';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -31,7 +32,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(result);
   } catch (err) {
-    console.error('[POST /api/ai/chat]', err);
-    return NextResponse.json({ error: 'AI 生成に失敗しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/ai/chat');
   }
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { hash } from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { registerSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, Conflict } from '@/lib/errors';
 
 export async function POST(req: NextRequest) {
   try {
@@ -19,10 +20,7 @@ export async function POST(req: NextRequest) {
 
     const existing = await prisma.user.findUnique({ where: { email } });
     if (existing) {
-      return NextResponse.json(
-        { error: 'このメールアドレスはすでに登録されています' },
-        { status: 409 }
-      );
+      throw Conflict('このメールアドレスはすでに登録されています');
     }
 
     const hashedPassword = await hash(password, 12);
@@ -34,11 +32,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ user }, { status: 201 });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error('[register]', message);
-    return NextResponse.json(
-      { error: process.env.NODE_ENV === 'development' ? message : 'サーバーエラーが発生しました' },
-      { status: 500 }
-    );
+    return handleApiError(err, 'POST /api/auth/register');
   }
 }

--- a/src/app/api/form/route.ts
+++ b/src/app/api/form/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { formSubmissionSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, NotFound } from '@/lib/errors';
 
 export async function POST(req: NextRequest) {
   try {
@@ -23,7 +24,7 @@ export async function POST(req: NextRequest) {
     });
 
     if (!page) {
-      return NextResponse.json({ error: 'ページが見つかりません' }, { status: 404 });
+      throw NotFound('ページが見つかりません');
     }
 
     await prisma.formSubmission.create({
@@ -32,7 +33,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true }, { status: 201 });
   } catch (err) {
-    console.error('[POST /api/form]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/form');
   }
 }

--- a/src/app/api/pages/[pageId]/publish/route.ts
+++ b/src/app/api/pages/[pageId]/publish/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { revalidatePath } from 'next/cache';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { handleApiError, NotFound, BadRequest } from '@/lib/errors';
 
 type Params = { params: Promise<{ pageId: string }> };
 
@@ -22,11 +23,11 @@ export async function POST(req: NextRequest, { params }: Params) {
     });
 
     if (!page) {
-      return NextResponse.json({ error: 'ページが見つかりません' }, { status: 404 });
+      throw NotFound('ページが見つかりません');
     }
 
     if (!page.isPublished) {
-      return NextResponse.json({ error: 'ページが公開されていません' }, { status: 400 });
+      throw BadRequest('ページが公開されていません。先に公開ステータスを「公開中」に変更してください');
     }
 
     // published_at を現在時刻に更新してキャッシュを無効化
@@ -39,7 +40,6 @@ export async function POST(req: NextRequest, { params }: Params) {
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error('[POST /api/pages/:id/publish]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/pages/:id/publish');
   }
 }

--- a/src/app/api/pages/[pageId]/route.ts
+++ b/src/app/api/pages/[pageId]/route.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { updatePageSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, NotFound } from '@/lib/errors';
 
 type Params = { params: Promise<{ pageId: string }> };
 
@@ -32,7 +33,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     });
 
     if (!page) {
-      return NextResponse.json({ error: 'ページが見つかりません' }, { status: 404 });
+      throw NotFound('ページが見つかりません');
     }
 
     const updateFields: Record<string, unknown> = {};
@@ -57,8 +58,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     return NextResponse.json({ page: updated });
   } catch (err) {
-    console.error('[PATCH /api/pages/:id]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'PATCH /api/pages/:id');
   }
 }
 
@@ -76,13 +76,12 @@ export async function DELETE(req: NextRequest, { params }: Params) {
     });
 
     if (!page) {
-      return NextResponse.json({ error: 'ページが見つかりません' }, { status: 404 });
+      throw NotFound('ページが見つかりません');
     }
 
     await prisma.page.delete({ where: { id: pageId } });
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error('[DELETE /api/pages/:id]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'DELETE /api/pages/:id');
   }
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createProjectSchema, formatZodError } from '@/lib/validations';
+import { handleApiError } from '@/lib/errors';
 
 // スラッグ生成：日本語も含む名前をローマ字 or ランダム文字列に変換
 function generateSlug(name: string): string {
@@ -54,7 +55,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ project }, { status: 201 });
   } catch (err) {
-    console.error('[POST /api/projects]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/projects');
   }
 }

--- a/src/app/api/sections/[sectionId]/route.ts
+++ b/src/app/api/sections/[sectionId]/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { updateSectionSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, NotFound } from '@/lib/errors';
 
 type Params = { params: Promise<{ sectionId: string }> };
 
@@ -34,7 +35,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     });
 
     if (!section) {
-      return NextResponse.json({ error: 'セクションが見つかりません' }, { status: 404 });
+      throw NotFound('セクションが見つかりません');
     }
 
     const updateFields: Prisma.SectionUpdateInput = {};
@@ -49,8 +50,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 
     return NextResponse.json({ section: updated });
   } catch (err) {
-    console.error('[PATCH /api/sections/:id]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'PATCH /api/sections/:id');
   }
 }
 
@@ -71,14 +71,13 @@ export async function DELETE(req: NextRequest, { params }: Params) {
     });
 
     if (!section) {
-      return NextResponse.json({ error: 'セクションが見つかりません' }, { status: 404 });
+      throw NotFound('セクションが見つかりません');
     }
 
     await prisma.section.delete({ where: { id: sectionId } });
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error('[DELETE /api/sections/:id]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'DELETE /api/sections/:id');
   }
 }

--- a/src/app/api/sections/reorder/route.ts
+++ b/src/app/api/sections/reorder/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { reorderSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, Forbidden } from '@/lib/errors';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -33,7 +34,7 @@ export async function POST(req: NextRequest) {
     });
 
     if (sections.length !== orders.length) {
-      return NextResponse.json({ error: '不正なセクションIDが含まれています' }, { status: 403 });
+      throw Forbidden('不正なセクションIDが含まれています');
     }
 
     await prisma.$transaction(
@@ -44,7 +45,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error('[POST /api/sections/reorder]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/sections/reorder');
   }
 }

--- a/src/app/api/sections/route.ts
+++ b/src/app/api/sections/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createSectionSchema, formatZodError } from '@/lib/validations';
+import { handleApiError, NotFound } from '@/lib/errors';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -33,7 +34,7 @@ export async function POST(req: NextRequest) {
     });
 
     if (!page) {
-      return NextResponse.json({ error: 'ページが見つかりません' }, { status: 404 });
+      throw NotFound('ページが見つかりません');
     }
 
     // 末尾に追加
@@ -52,7 +53,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ section }, { status: 201 });
   } catch (err) {
-    console.error('[POST /api/sections]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/sections');
   }
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { createClient } from '@supabase/supabase-js';
 import { prisma } from '@/lib/prisma';
+import { handleApiError, BadRequest } from '@/lib/errors';
 
 // サービスロールクライアント（Storage の RLS をバイパス）
 function getServiceClient() {
@@ -27,13 +28,13 @@ export async function POST(req: NextRequest) {
     const file = formData.get('file') as File | null;
 
     if (!file) {
-      return NextResponse.json({ error: 'ファイルが必要です' }, { status: 400 });
+      throw BadRequest('ファイルが必要です');
     }
     if (!ALLOWED_TYPES.includes(file.type)) {
-      return NextResponse.json({ error: 'JPEG / PNG / WebP / GIF のみアップロードできます' }, { status: 400 });
+      throw BadRequest('JPEG / PNG / WebP / GIF のみアップロードできます');
     }
     if (file.size > MAX_SIZE) {
-      return NextResponse.json({ error: 'ファイルサイズは5MB以下にしてください' }, { status: 400 });
+      throw BadRequest('ファイルサイズは5MB以下にしてください');
     }
 
     // ファイル拡張子をサニタイズ（英数字のみ許可）
@@ -50,8 +51,8 @@ export async function POST(req: NextRequest) {
       });
 
     if (uploadError) {
-      console.error('[upload]', uploadError);
-      return NextResponse.json({ error: 'アップロードに失敗しました' }, { status: 500 });
+      console.error('[upload] Supabase Storage error:', uploadError);
+      throw new Error(`ストレージへのアップロードに失敗しました: ${uploadError.message}`);
     }
 
     const { data: { publicUrl } } = supabase.storage.from(BUCKET).getPublicUrl(path);
@@ -69,7 +70,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ url: publicUrl }, { status: 201 });
   } catch (err) {
-    console.error('[POST /api/upload]', err);
-    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 });
+    return handleApiError(err, 'POST /api/upload');
   }
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -54,9 +54,17 @@ export async function generateSectionEdit(
   const jsonMatch = text.match(/\{[\s\S]*\}/);
   if (!jsonMatch) throw new Error('AI レスポンスから JSON を抽出できませんでした');
 
-  const parsed = JSON.parse(jsonMatch[0]);
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    throw new Error(
+      `AI レスポンスの JSON パースに失敗しました: ${jsonMatch[0].slice(0, 200)}`
+    );
+  }
+
   return {
-    data: parsed.data ?? currentData,
-    styleOverrides: parsed.styleOverrides ?? currentStyleOverrides,
+    data: (parsed.data as Record<string, unknown>) ?? currentData,
+    styleOverrides: (parsed.styleOverrides as Record<string, string>) ?? currentStyleOverrides,
   };
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+
+/**
+ * アプリケーション固有のエラー
+ * API ルートで意図的に throw してステータスコードを制御する
+ */
+export class AppError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+// 便利なファクトリ関数
+export const BadRequest = (message: string) => new AppError(400, message);
+export const Unauthorized = (message = '認証が必要です') => new AppError(401, message);
+export const Forbidden = (message = 'アクセス権限がありません') => new AppError(403, message);
+export const NotFound = (message = 'リソースが見つかりません') => new AppError(404, message);
+export const Conflict = (message: string) => new AppError(409, message);
+
+/**
+ * catch ブロック用の共通エラーハンドラ
+ *
+ * エラーの種類に応じて適切な HTTP ステータスコードを返す:
+ * - AppError        → そのまま statusCode を使用
+ * - Prisma P2002    → 409 Conflict（ユニーク制約違反）
+ * - Prisma P2025    → 404 Not Found（レコード未発見）
+ * - SyntaxError     → 400 Bad Request（JSON パース失敗など）
+ * - その他          → 500 Internal Server Error
+ */
+export function handleApiError(err: unknown, context: string): NextResponse {
+  // アプリケーションエラー（意図的に throw したもの）
+  if (err instanceof AppError) {
+    return NextResponse.json({ error: err.message }, { status: err.statusCode });
+  }
+
+  // JSON パースエラー（不正なリクエストボディ）
+  if (err instanceof SyntaxError) {
+    return NextResponse.json(
+      { error: 'リクエストの形式が不正です' },
+      { status: 400 }
+    );
+  }
+
+  // Prisma 固有エラー
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    switch (err.code) {
+      case 'P2002': {
+        // ユニーク制約違反
+        const target = (err.meta?.target as string[])?.join(', ') ?? '不明なフィールド';
+        return NextResponse.json(
+          { error: `${target} はすでに使用されています` },
+          { status: 409 }
+        );
+      }
+      case 'P2025':
+        // レコード未発見（update/delete 対象が存在しない）
+        return NextResponse.json(
+          { error: '対象のデータが見つかりません' },
+          { status: 404 }
+        );
+      case 'P2003':
+        // 外部キー制約違反
+        return NextResponse.json(
+          { error: '関連するデータが見つかりません' },
+          { status: 400 }
+        );
+      default:
+        console.error(`[${context}] Prisma error ${err.code}:`, err.message);
+        return NextResponse.json(
+          { error: 'データベースエラーが発生しました' },
+          { status: 500 }
+        );
+    }
+  }
+
+  // Prisma バリデーションエラー（型不一致など）
+  if (err instanceof Prisma.PrismaClientValidationError) {
+    console.error(`[${context}] Prisma validation:`, err.message);
+    return NextResponse.json(
+      { error: 'データの形式が不正です' },
+      { status: 400 }
+    );
+  }
+
+  // 予期しないエラー
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[${context}]`, message);
+
+  return NextResponse.json(
+    {
+      error: 'サーバーエラーが発生しました',
+      // 開発環境のみ詳細を返す
+      ...(process.env.NODE_ENV === 'development' && { detail: message }),
+    },
+    { status: 500 }
+  );
+}


### PR DESCRIPTION
## Summary
- `src/lib/errors.ts` に共通エラーハンドリングユーティリティを新設（`AppError` クラス + `handleApiError()` 関数）
- 全 API ルート（12ファイル）の catch ブロックを `handleApiError()` に統一し、エラー種別に応じた適切な HTTP ステータスコードを返すように改善
- `src/lib/ai.ts` の `JSON.parse` に try-catch を追加し、AI が不正な JSON を返した場合のクラッシュを防止

## エラー判定ロジック
| エラー種別 | HTTP Status | 例 |
|-----------|-------------|-----|
| `AppError` | そのまま（400/404/409等） | `throw NotFound('ページが見つかりません')` |
| `SyntaxError` | 400 | 不正な JSON リクエストボディ |
| Prisma `P2002` | 409 | ユニーク制約違反 |
| Prisma `P2025` | 404 | update/delete 対象が存在しない |
| Prisma `P2003` | 400 | 外部キー制約違反 |
| その他 | 500 | 開発環境のみ `detail` で詳細返却 |

## Test plan
- [ ] `npm run build` がエラーなしで通ること
- [ ] `npm run lint` がエラーなしで通ること
- [ ] 存在しないリソースへのリクエストで 404 が返ること
- [ ] 不正な JSON ボディで 400 が返ること（500 にならないこと）
- [ ] AI チャットで Claude が不正 JSON を返した場合に具体的なエラーメッセージが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)