### PR TITLE
AIチャットの色変更がセクション全体に反映されるよう修正

### DIFF
--- a/src/components/sections/CtaSection.tsx
+++ b/src/components/sections/CtaSection.tsx
@@ -13,12 +13,12 @@ export default function CtaSection({ data, styleOverrides }: Props) {
     >
       <h2
         className="mb-4 text-4xl font-bold"
-        style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+        style={{ fontFamily: 'var(--font-heading)' }}
       >
         {data.headline}
       </h2>
       {data.subheadline && (
-        <p className="mb-8 text-lg" style={{ color: 'var(--text)', opacity: 0.7 }}>
+        <p className="mb-8 text-lg" style={{ opacity: 0.7 }}>
           {data.subheadline}
         </p>
       )}

--- a/src/components/sections/FaqSection.tsx
+++ b/src/components/sections/FaqSection.tsx
@@ -23,7 +23,7 @@ export default function FaqSection({ data, styleOverrides }: Props) {
     >
       <h2
         className="mb-12 text-center text-3xl font-bold"
-        style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+        style={{ fontFamily: 'var(--font-heading)' }}
       >
         {data.title}
       </h2>
@@ -40,7 +40,6 @@ export default function FaqSection({ data, styleOverrides }: Props) {
           >
             <button
               className="flex w-full items-center justify-between px-5 py-4 text-left font-medium"
-              style={{ color: 'var(--text)' }}
               onClick={() => setOpenIndex(openIndex === i ? null : i)}
             >
               {item.question}
@@ -51,7 +50,6 @@ export default function FaqSection({ data, styleOverrides }: Props) {
                 className="border-t px-5 py-4 text-sm"
                 style={{
                   borderColor: 'color-mix(in srgb, var(--text) 10%, transparent)',
-                  color: 'var(--text)',
                   opacity: 0.75,
                 }}
               >

--- a/src/components/sections/FeaturesSection.tsx
+++ b/src/components/sections/FeaturesSection.tsx
@@ -13,7 +13,7 @@ export default function FeaturesSection({ data, styleOverrides }: Props) {
     >
       <h2
         className="mb-12 text-center text-3xl font-bold"
-        style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+        style={{ fontFamily: 'var(--font-heading)' }}
       >
         {data.title}
       </h2>
@@ -31,11 +31,11 @@ export default function FeaturesSection({ data, styleOverrides }: Props) {
             {item.icon && <div className="mb-3 text-3xl">{item.icon}</div>}
             <h3
               className="mb-2 font-semibold"
-              style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+              style={{ fontFamily: 'var(--font-heading)' }}
             >
               {item.title}
             </h3>
-            <p className="text-sm" style={{ color: 'var(--text)', opacity: 0.7 }}>
+            <p className="text-sm" style={{ opacity: 0.7 }}>
               {item.description}
             </p>
           </div>

--- a/src/components/sections/FormSection.tsx
+++ b/src/components/sections/FormSection.tsx
@@ -43,13 +43,13 @@ export default function FormSection({ data, styleOverrides, pageId }: Props) {
         {data.title && (
           <h2
             className="mb-3 text-center text-3xl font-bold"
-            style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+            style={{ fontFamily: 'var(--font-heading)' }}
           >
             {data.title}
           </h2>
         )}
         {data.description && (
-          <p className="mb-8 text-center" style={{ color: 'var(--text)', opacity: 0.7 }}>
+          <p className="mb-8 text-center" style={{ opacity: 0.7 }}>
             {data.description}
           </p>
         )}
@@ -59,7 +59,6 @@ export default function FormSection({ data, styleOverrides, pageId }: Props) {
             className="rounded-lg p-6 text-center text-sm"
             style={{
               backgroundColor: 'color-mix(in srgb, var(--accent) 10%, transparent)',
-              color: 'var(--text)',
               borderRadius: 'var(--radius)',
             }}
           >
@@ -71,7 +70,6 @@ export default function FormSection({ data, styleOverrides, pageId }: Props) {
               <div key={field.name}>
                 <label
                   className="mb-1 block text-sm font-medium"
-                  style={{ color: 'var(--text)' }}
                 >
                   {field.label}
                   {field.required && <span style={{ color: 'var(--accent)' }}> *</span>}

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -21,12 +21,12 @@ export default function HeroSection({ data, styleOverrides }: Props) {
       <div className="relative z-10 px-6">
         <h1
           className="text-5xl font-bold"
-          style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+          style={{ fontFamily: 'var(--font-heading)' }}
         >
           {data.headline}
         </h1>
         {data.subheadline && (
-          <p className="mt-4 text-xl" style={{ color: 'var(--text)', opacity: 0.75 }}>
+          <p className="mt-4 text-xl" style={{ opacity: 0.75 }}>
             {data.subheadline}
           </p>
         )}

--- a/src/components/sections/PricingSection.tsx
+++ b/src/components/sections/PricingSection.tsx
@@ -13,7 +13,7 @@ export default function PricingSection({ data, styleOverrides }: Props) {
     >
       <h2
         className="mb-12 text-center text-3xl font-bold"
-        style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+        style={{ fontFamily: 'var(--font-heading)' }}
       >
         {data.title}
       </h2>
@@ -31,11 +31,11 @@ export default function PricingSection({ data, styleOverrides }: Props) {
           >
             <h3
               className="mb-2 text-xl font-bold"
-              style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+              style={{ fontFamily: 'var(--font-heading)' }}
             >
               {plan.name}
             </h3>
-            <p className="mb-4 text-3xl font-bold" style={{ color: 'var(--text)' }}>
+            <p className="mb-4 text-3xl font-bold">
               {plan.price}
               <span className="text-base font-normal" style={{ opacity: 0.6 }}>/{plan.period}</span>
             </p>
@@ -43,12 +43,12 @@ export default function PricingSection({ data, styleOverrides }: Props) {
               {plan.features.map((f, j) => (
                 <li key={j} className="flex items-center gap-2">
                   <span style={{ color: 'var(--accent)' }}>✓</span>
-                  <span style={{ color: 'var(--text)', opacity: 0.85 }}>{f}</span>
+                  <span style={{ opacity: 0.85 }}>{f}</span>
                 </li>
               ))}
             </ul>
             {plan.note && (
-              <p className="mb-4 text-xs" style={{ color: 'var(--text)', opacity: 0.55 }}>{plan.note}</p>
+              <p className="mb-4 text-xs" style={{ opacity: 0.55 }}>{plan.note}</p>
             )}
             {plan.ctaText && (
               <a

--- a/src/components/sections/TestimonialsSection.tsx
+++ b/src/components/sections/TestimonialsSection.tsx
@@ -18,7 +18,7 @@ export default function TestimonialsSection({ data, styleOverrides }: Props) {
     >
       <h2
         className="mb-12 text-center text-3xl font-bold"
-        style={{ fontFamily: 'var(--font-heading)', color: 'var(--text)' }}
+        style={{ fontFamily: 'var(--font-heading)' }}
       >
         {data.title}
       </h2>
@@ -30,10 +30,9 @@ export default function TestimonialsSection({ data, styleOverrides }: Props) {
             style={{
               backgroundColor: 'var(--bg)',
               borderRadius: 'var(--radius)',
-              color: 'var(--text)',
             }}
           >
-            <p className="mb-4" style={{ color: 'var(--text)', opacity: 0.8 }}>
+            <p className="mb-4" style={{ opacity: 0.8 }}>
               &ldquo;{item.body}&rdquo;
             </p>
             <div className="flex items-center gap-3">
@@ -41,9 +40,9 @@ export default function TestimonialsSection({ data, styleOverrides }: Props) {
                 <img src={item.avatarUrl} alt={item.name} className="h-10 w-10 rounded-full object-cover" />
               )}
               <div>
-                <p className="font-semibold" style={{ color: 'var(--text)' }}>{item.name}</p>
+                <p className="font-semibold">{item.name}</p>
                 {item.role && (
-                  <p className="text-sm" style={{ color: 'var(--text)', opacity: 0.6 }}>{item.role}</p>
+                  <p className="text-sm" style={{ opacity: 0.6 }}>{item.role}</p>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- セクション子要素（h1, h2, h3, p, button 等）から `color: var(--text)` のハードコードを削除
- 親 `<section>` の `color` が CSS の自然な継承で子要素に伝播するように変更
- AIチャットが `styleOverrides` で `{ color: '#ff0000' }` を返した場合、セクション全体の文字色が正しく反映される

## 変更方針
- `opacity` のみの指定 → 残す（テンプレートの視覚階層を維持）
- フォーム入力欄（input/textarea）の `color` → 残す（フォーム要素は `inherit` が効きにくい）
- Footer のリンク `color: var(--bg)` → 残す（背景色と文字色が逆転するセクション）

## 対象ファイル（7件）
HeroSection / FeaturesSection / TestimonialsSection / PricingSection / FaqSection / CtaSection / FormSection

## Test plan
- [ ] `npm run build` がエラーなしで通ること
- [ ] テンプレートごとにプレビューでデフォルト表示が変わっていないこと
- [ ] AIチャットで「文字色を赤にして」と指示し、セクション全体の文字色が変わること
- [ ] Footer の文字色が白系のまま表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)