### PR TITLE
fix: uuid → cuid バリデーション修正 & natural テンプレート追加

### DIFF
--- a/src/app/p/[slug]/page.tsx
+++ b/src/app/p/[slug]/page.tsx
@@ -13,6 +13,7 @@ const FONT_URLS: Record<GlobalConfig['template'], string> = {
   premium:  'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap',
   pop:      'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&display=swap',
   business: 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap',
+  natural:  'https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Raleway:wght@300;400;500;600;700&display=swap',
 };
 
 export default async function PublicLPPage({ params }: Props) {

--- a/src/components/editor/Preview.tsx
+++ b/src/components/editor/Preview.tsx
@@ -67,6 +67,7 @@ export default function Preview({ sections, selectedId, onSelect, onAIClick, pre
     premium:  'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap',
     pop:      'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&display=swap',
     business: 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap',
+    natural:  'https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Raleway:wght@300;400;500;600;700&display=swap',
   };
 
   return (

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -2,6 +2,7 @@ import { simpleTemplate } from './simple';
 import { premiumTemplate } from './premium';
 import { popTemplate } from './pop';
 import { businessTemplate } from './business';
+import { naturalTemplate } from './natural';
 import type { GlobalConfig } from '@/types/section';
 
 export const TEMPLATES: Record<GlobalConfig['template'], {
@@ -13,4 +14,5 @@ export const TEMPLATES: Record<GlobalConfig['template'], {
   premium: premiumTemplate,
   pop: popTemplate,
   business: businessTemplate,
+  natural: naturalTemplate,
 };

--- a/src/lib/templates/natural.ts
+++ b/src/lib/templates/natural.ts
@@ -1,0 +1,12 @@
+export const naturalTemplate = {
+  name: 'natural',
+  label: 'ナチュラル',
+  cssVars: {
+    '--accent': '#2D8A6E',
+    '--bg': '#FAFAF7',
+    '--text': '#2C3E2D',
+    '--font-heading': "'Lora', serif",
+    '--font-body': "'Raleway', sans-serif",
+    '--radius': '16px',
+  },
+} as const;

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -50,7 +50,7 @@ export const sectionTypeEnum = z.enum([
 ]);
 
 export const createSectionSchema = z.object({
-  pageId: z.string().uuid('pageId の形式が不正です'),
+  pageId: z.string().cuid('pageId の形式が不正です'),
   type: sectionTypeEnum,
 });
 
@@ -69,7 +69,7 @@ export const reorderSchema = z.object({
   orders: z
     .array(
       z.object({
-        id: z.string().uuid('セクションIDの形式が不正です'),
+        id: z.string().cuid('セクションIDの形式が不正です'),
         order: z.number().int().min(0, 'order は0以上の整数にしてください'),
       })
     )
@@ -95,7 +95,7 @@ export const updatePageSchema = z
 // フォーム送信（公開LP）
 // ========================================
 export const formSubmissionSchema = z.object({
-  pageId: z.string().uuid('pageId の形式が不正です'),
+  pageId: z.string().cuid('pageId の形式が不正です'),
   data: z.record(z.string(), z.unknown()).refine((obj) => Object.keys(obj).length > 0, {
     message: 'フォームデータが空です',
   }),

--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -11,7 +11,7 @@ export type SectionType =
 
 // ページ全体のグローバル設定（テーマ）
 export type GlobalConfig = {
-  template: 'simple' | 'premium' | 'pop' | 'business';
+  template: 'simple' | 'premium' | 'pop' | 'business' | 'natural';
   cssVars?: Record<string, string>;
 };
 


### PR DESCRIPTION
## Summary
- バリデーションスキーマの `.uuid()` を `.cuid()` に修正。Prisma が `cuid()` でIDを生成しているため、UUID形式チェックでセクション追加・並び替え・フォーム送信が400エラーになっていた
- `natural` テンプレートを追加（Lora + Raleway フォント）

## Test plan
- [ ] セクション追加が正常に動作する
- [ ] セクション並び替えが正常に動作する
- [ ] フォーム送信が正常に動作する
- [ ] natural テンプレートがエディター・公開ページで反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)