### PR TITLE
feat: Features grid variant に画像対応を追加

### DIFF
--- a/docs/sections-and-templates.md
+++ b/docs/sections-and-templates.md
@@ -7,7 +7,7 @@
 | `hero` | `centered` | テキスト・CTAを中央配置 |
 | `hero` | `split` | 左テキスト＋右画像の2カラム |
 | `hero` | `fullscreen` | 100vh グラデーション背景・左テキスト＋右装飾 |
-| `features` | `grid` | カード型グリッド（2-3カラム） |
+| `features` | `grid` | カード型グリッド（2-3カラム・画像はカード上部ヘッダー、object-contain で全体表示） |
 | `features` | `alternating` | 左右交互レイアウト（画像+テキスト） |
 | `testimonials` | `cards` | カード型並び |
 | `testimonials` | `single` | 1件ずつ大きく表示 |
@@ -62,6 +62,15 @@ type HeroSectionData = {
 ```
 
 variant 未指定時は `DEFAULT_VARIANTS[type]` にフォールバック。
+
+### Features セクションの画像/アイコン表示ルール
+
+grid / alternating 両 variant 共通:
+- `item.image` あり → 画像のみ表示（アイコンは無視）
+- `item.image` なし、`item.icon` あり → アイコンのみ表示
+- 両方なし → alternating はプレースホルダー SVG、grid はタイトル・説明のみ
+
+grid variant の画像表示: `aspect-video` ラッパー内に `object-contain` で全体表示。余白背景は `var(--bg)`。縦長・横長どちらの画像も切り抜かずに表示される。
 
 ### 新規追加セクションのデータ型
 

--- a/src/components/editor/forms/FeaturesForm.tsx
+++ b/src/components/editor/forms/FeaturesForm.tsx
@@ -127,8 +127,7 @@ export default function FeaturesForm({ data, onUpdate }: Props) {
                   placeholder="説明文"
                   className={`${inputClass} resize-none`}
                 />
-                {variant === 'alternating' && (
-                  <div>
+                <div>
                     {item.image ? (
                       <div className="space-y-1">
                         <img src={item.image} alt="" className="h-20 w-full rounded-lg object-cover" />
@@ -157,8 +156,7 @@ export default function FeaturesForm({ data, onUpdate }: Props) {
                         />
                       </>
                     )}
-                  </div>
-                )}
+                </div>
               </div>
             </div>
           ))}

--- a/src/components/sections/FeaturesSection.tsx
+++ b/src/components/sections/FeaturesSection.tsx
@@ -98,14 +98,30 @@ export default function FeaturesSection({ data, styleOverrides }: Props) {
       <div className="mx-auto mt-3 w-12" style={{ borderBottom: 'var(--heading-accent)' }} />
       <div className="mx-auto mt-8 grid max-w-5xl gap-6 sm:grid-cols-2 md:mt-12 md:gap-8 lg:grid-cols-3">
         {data.items.map((item, i) => (
-          <div key={i} className="hover-lift p-5 md:p-6" style={cardStyle}>
-            {item.icon && <div className="mb-2 text-2xl md:mb-3 md:text-3xl">{item.icon}</div>}
-            <h3 className="mb-2 font-semibold" style={{ fontFamily: 'var(--font-heading)' }}>
-              {item.title}
-            </h3>
-            <p className="whitespace-pre-wrap text-sm" style={{ opacity: 0.7 }}>
-              {item.description}
-            </p>
+          <div key={i} className="hover-lift overflow-hidden" style={cardStyle}>
+            {item.image && (
+              <div
+                className="aspect-video w-full"
+                style={{ backgroundColor: 'var(--bg)' }}
+              >
+                <img
+                  src={item.image}
+                  alt={item.title}
+                  className="h-full w-full object-contain"
+                />
+              </div>
+            )}
+            <div className="p-5 md:p-6">
+              {!item.image && item.icon && (
+                <div className="mb-2 text-2xl md:mb-3 md:text-3xl">{item.icon}</div>
+              )}
+              <h3 className="mb-2 font-semibold" style={{ fontFamily: 'var(--font-heading)' }}>
+                {item.title}
+              </h3>
+              <p className="whitespace-pre-wrap text-sm" style={{ opacity: 0.7 }}>
+                {item.description}
+              </p>
+            </div>
           </div>
         ))}
       </div>

--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -44,7 +44,7 @@ export type HeroSectionData = {
 
 export type FeatureItem = {
   icon?: string;
-  image?: string; // alternating variant: 各アイテムの画像
+  image?: string; // 各アイテムの画像（grid / alternating 両対応・画像優先）
   title: string;
   description: string;
 };


### PR DESCRIPTION
## Summary

- grid variant のカード上部に画像ヘッダーを追加（`object-contain` で全体表示・切り抜きなし）
- 画像優先ルール（画像 > アイコン > なし）を grid / alternating 両 variant で統一
- FeaturesForm の画像アップロード UI を variant に関わらず常に表示
- `FeatureItem.image` のコメントを両 variant 対応に更新

## Test plan

- [ ] grid variant で画像ありのアイテムがカード上部に表示されることを確認
- [ ] 縦長・横長画像が切り抜かれず `object-contain` で表示されることを確認
- [ ] 画像なし・アイコンありのアイテムでアイコンが表示されることを確認
- [ ] 両方なしのアイテムでタイトル・説明のみ表示されることを確認
- [ ] エディターで grid variant 選択時に画像アップロード UI が表示されることを確認
- [ ] variant を grid ↔ alternating で切り替えても画像データが保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)